### PR TITLE
Moved upload folder to routes, created as documents are uploaded.

### DIFF
--- a/ucr_chatbot/db/models.py
+++ b/ucr_chatbot/db/models.py
@@ -13,7 +13,6 @@ from sqlalchemy.orm import declarative_base, mapped_column, relationship, Sessio
 import enum
 from pgvector.sqlalchemy import Vector  # type: ignore
 from datetime import datetime, timezone
-from pathlib import Path
 from sqlalchemy.exc import SQLAlchemyError
 import pandas as pd
 from typing import cast
@@ -270,7 +269,6 @@ def add_new_course(name: str):
             session.add(new_course)
             session.commit()
 
-            create_upload_folder(getattr(new_course, "id"))
         except SQLAlchemyError:
             session.rollback()
 
@@ -355,15 +353,3 @@ def store_embedding(embedding: Sequence[float], segment_id: int):
             session.commit()
         except SQLAlchemyError:
             session.rollback()
-
-
-def create_upload_folder(course_id: int):
-    """Creates a folder named after the course id within the uploads folder.
-    :param course_id: name of the folder to be created
-    """
-    upload_path = Path(Config.FILE_STORAGE_PATH)
-    if not upload_path.is_dir():
-        upload_path.mkdir(parents=True, exist_ok=True)
-
-    course_path = upload_path / str(course_id)
-    course_path.mkdir(parents=True, exist_ok=True)

--- a/ucr_chatbot/web_interface/routes.py
+++ b/ucr_chatbot/web_interface/routes.py
@@ -559,6 +559,19 @@ def conversation(conversation_id: int):
         )
 
 
+def create_upload_folder(course_id: int):
+    """Creates a folder named after the course id within the uploads folder.
+    :param course_id: name of the folder to be created
+    """
+    upload_path = Path(Config.FILE_STORAGE_PATH)
+    if not upload_path.is_dir():
+        upload_path.mkdir(parents=True, exist_ok=True)
+
+    course_path = upload_path / str(course_id)
+    if not course_path.is_dir():
+        course_path.mkdir(parents=True, exist_ok=True)
+
+
 @bp.route("/course/<int:course_id>/documents", methods=["GET", "POST"])
 @login_required
 @roles_required(["instructor"])
@@ -606,6 +619,7 @@ def course_documents(course_id: int):
             relative_path = Path(str(course_id)) / filename
             full_local_path = curr_path / relative_path
 
+            create_upload_folder(course_id=course_id)
             file.save(str(full_local_path))
 
             segments = parse_file(str(full_local_path))


### PR DESCRIPTION
Resolves #34 

The upload folder, and its corresponding course_id subfolders, are created once a document is uploaded for that course. 
This works on the machines I can test on, I'm not sure what the but was before in not creating the uploads folder before, but now it does it dynamically.